### PR TITLE
Saxon 9.6 Parameter Tunneling

### DIFF
--- a/common_top_level_tables.xsl
+++ b/common_top_level_tables.xsl
@@ -218,8 +218,8 @@
       (observables, indicators, TTPs, etc).
     -->
   <xsl:template name="processTopLevelCategory">
-    <xsl:param name="reference" select="()" tunnel="no" />
-    <xsl:param name="normalized" select="()" tunnel="no" />
+    <xsl:param name="reference" select="()" tunnel="yes" />
+    <xsl:param name="normalized" select="()" tunnel="yes" />
     <xsl:param name="categoryGroupingElement" select="()"/>
     <xsl:param name="headingLabels" select="('Type', 'ID')"/>
     <xsl:param name="headingColumnStyles" select="('typeColumn', 'idColumn')"/>
@@ -294,8 +294,8 @@
       level category tables.
     -->
   <xsl:template name="printGenericItemForTopLevelCategoryTable">
-    <xsl:param name="reference" select="()" tunnel="no" />
-    <xsl:param name="normalized" select="()" tunnel="no" />
+    <xsl:param name="reference" select="()" tunnel="yes" />
+    <xsl:param name="normalized" select="()" tunnel="yes" />
     <xsl:param name="colCount" select="2" />
     
     <xsl:variable name="originalItem" select="." />

--- a/stix_to_html.xsl
+++ b/stix_to_html.xsl
@@ -613,8 +613,8 @@ mdunn@mitre.org
     and building this content.
   -->
   <xsl:template name="printReference">
-    <xsl:param name="reference" select="()" tunnel="no" />
-    <xsl:param name="normalized" select="()" tunnel="no" />
+    <xsl:param name="reference" select="()" tunnel="yes" />
+    <xsl:param name="normalized" select="()" tunnel="yes" />
 
     <div class="reference">
       <xsl:apply-templates select="$reference" mode="printReference"/>


### PR DESCRIPTION
This pull request aims to address some issues surrounding parameter tunneling in Saxon 9.6. Changing `tunnel="yes"` to `tunnel="no"` in 8df65cd059e3b82775f16361c56d5d8b24f6caf0 seemed to have unintentionally stripped a `<div class="reference">` from the output html document, thereby breaking the div expansion.

This has been tested with Saxon 9.5 and 9.6 and _seems_ to work, but I'm unsure of the consequences of applying `tunnel="yes"` all over the place :)
